### PR TITLE
Fixed tests with standalone imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:12.4
+      - image: circleci/node:13
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:12.4
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
 
     working_directory: ~/repo
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 **/*.js
 **/*.js.map
 **/*.d.ts
+!*.config.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "12",
+        },
+      },
+    ],
+    "@babel/preset-react",
+    "@babel/preset-typescript",
+  ],
+};

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
   "moduleNameMapper": {
-    "mock-redux": "<rootDir>/src/index"
+    "^mock-redux$": "<rootDir>/src/index"
   },
   "testRegex": ["\\.test\\.tsx?$"]
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,3 +1,6 @@
 {
+  "moduleNameMapper": {
+    "mock-redux": "<rootDir>/src/index"
+  },
   "testRegex": ["\\.test\\.tsx?$"]
 }

--- a/src/tests/Provider.test.tsx
+++ b/src/tests/Provider.test.tsx
@@ -1,9 +1,8 @@
+import "mock-redux";
+import { Provider } from "react-redux";
+
 describe("Provider", () => {
   it("throws an error when mock-redux has been imported", async () => {
-    await import("mock-redux");
-
-    const { Provider } = await import("react-redux");
-
     expect(Provider).toThrowError("Provider is not supported when using mock-redux.");
   });
 });

--- a/src/tests/connect.test.tsx
+++ b/src/tests/connect.test.tsx
@@ -1,8 +1,8 @@
+import "mock-redux";
+import { connect } from "react-redux";
+
 describe("connect", () => {
   it("throws an error when mock-redux has been imported", async () => {
-    await import("mock-redux");
-    const { connect } = await import("react-redux");
-
     expect(connect).toThrowError("connect is not supported when using mock-redux.");
   });
 });

--- a/src/tests/mockRedux.test.tsx
+++ b/src/tests/mockRedux.test.tsx
@@ -1,8 +1,8 @@
+import "react-redux";
+import { mockRedux } from "mock-redux";
+
 describe("mockRedux", () => {
   it("throws an error when required after react-redux", async () => {
-    await import("react-redux");
-    const { mockRedux } = await import("mock-redux");
-
     expect(mockRedux).toThrowError(
       "It looks like you imported react-redux before mock-redux. Put mock-redux before react-redux or any imports that include react-redux.",
     );


### PR DESCRIPTION
What an unfortunate error:

```
 FAIL  src/tests/connect.test.tsx
 
  ● connect › throws an error when mock-redux has been imported
 
    TypeError: A dynamic import callback was not specified.TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.
 
      1 | describe("connect", () => {
      2 |   it("throws an error when mock-redux has been imported", async () => {
    > 3 |     await import("mock-redux");
        |     ^
      4 |     const { connect } = await import("react-redux");
      5 | 
      6 |     expect(connect).toThrowError("connect is not supported when using mock-redux.");

      at Object.<anonymous> (src/tests/connect.test.tsx:3:5)
 ```