### PR TITLE
Added FAQs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See [Dispatches](./docs/Dispatches.md) for more documentation or [Clicker](./doc
 - The first `mock-redux` import _must_ come before the first `react-redux` import in your test files.
 - `.give` and `.giveMock` will only apply when selectors are passed directly to `useSelector` (e.g. `useSelector(selectValue)`).
   - For inline selectors such as `useSelector(state => selectValue(state))`, use the `.state` API to set the root state value.
+  - See [FAQs](./docs/FAQs.md#help-my-give-selectors-arent-getting-mocked) for more tips and tricks.
 
 ### Hybrid Usage
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [Dispatches](./docs/Dispatches.md) for more documentation or [Clicker](./doc
 ### Hybrid Usage
 
 You don't have to use `mock-redux` in _every_ test file in your repository.
-Only the test files that import `mock-redux` will have Redux actions stubbed out.
+Only the test files that import `mock-redux` will have `react-redux` stubbed out.
 
 ### TypeScript Usage
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 [![Circle CI](https://img.shields.io/circleci/build/github/Codecademy/mock-redux.svg)](https://circleci.com/gh/Codecademy/mock-redux)
 [![Join the chat at https://gitter.im/Codecademy/mock-redux](https://badges.gitter.im/Codecademy/mock-redux.svg)](https://gitter.im/Codecademy/mock-redux?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Mocks out Redux actions and selectors for clean React unit tests in Jest.
+Mocks out Redux actions and selectors for clean React Jest tests.
 
-Tired of setting up, updating, and debugging through complex _Redux_ states in your _React_ unit tests?
-Use this package if you'd like your React component tests to not take dependencies on your full Redux states.
+Tired of setting up, updating, and debugging through complex _Redux_ states in your _React_ tests?
+Use this package if you'd like your React component tests to not take dependencies on your full Redux store.
 
 > See [FAQs](./docs/FAQs.md) for more backing information. 📚
 
@@ -24,7 +24,7 @@ import { mockRedux } from "mock-redux";
 ```
 
 `mock-redux` stubs out [`connect`](https://react-redux.js.org/api/connect) and the [two common Redux hooks](https://react-redux.js.org/api/hooks) used with React components.
-Call `mockRedux()` before your render/mount logic in each unit test.
+Call `mockRedux()` before your render/mount logic in each test.
 
 ### Mocking State
 
@@ -84,7 +84,7 @@ const { dispatch } = mockRedux();
 ```
 
 The `dispatch` function returned by [`useDispatch`](https://react-redux.js.org/api/hooks#usedispatch) will be replaced by a `jest.fn()` spy.
-You can then assert against it as with any Jest mock in your unit tests:
+You can then assert against it as with any Jest mock in your tests:
 
 ```tsx
 it("dispatches the pageLoaded action when rendered", () => {
@@ -107,7 +107,7 @@ See [Dispatches](./docs/Dispatches.md) for more documentation or [Clicker](./doc
 
 ### Hybrid Usage
 
-You don't have to use `mock-redux` in _every_ unit test file in your repository.
+You don't have to use `mock-redux` in _every_ test file in your repository.
 Only the test files that import `mock-redux` will have Redux actions stubbed out.
 
 ### TypeScript Usage

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
 
 Mocks out Redux actions and selectors for clean React unit tests in Jest.
 
-Use this package if you'd like your React component unit tests to not take dependencies on your full Redux states.
-Separating your unit tests in this way can be particularly useful if your Redux state is complex and/or shared across components.
+Tired of setting up, updating, and debugging through complex _Redux_ states in your _React_ unit tests?
+Use this package if you'd like your React component tests to not take dependencies on your full Redux states.
+
+> See [FAQs](./docs/FAQs.md) for more backing information. 📚
 
 ## Usage
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -4,12 +4,17 @@
 
 Maybe!
 
+For starters, this library is _very new_ and has yet to undergo the vigorous heated Twitter debates that all popular JavaScript libraries go through -- if ever will.
+Take everything here with a grain of salt.
+
 `mock-redux` is excellent for separating your React and Redux logic areas.
 Many applications intentionally try to independently test the two areas.
 This approach is particularily effective in applications that do some or all of:
 
 - Keep a large amount of data in their Redux state and/or share pieces of that state among multiple components
 - Test Redux logic (actions, selectors, and/or reducers) in isolation from React components
+
+See Mark Erikson's [Redux testing strategy blog post](https://blog.isquaredsoftware.com/2019/07/blogged-answers-thoughts-on-hooks/) for prior discussion and thoughts.
 
 ## How Is `mock-redux` Different Than Other Redux Test Libraries?
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -1,0 +1,89 @@
+# Frequently Asked Questions
+
+## Should I Use `mock-redux`?
+
+Maybe!
+
+`mock-redux` is excellent for separating your React and Redux logic areas.
+Many applications intentionally try to independently test the two areas.
+This approach is particularily effective in applications that do some or all of:
+
+- Keep a large amount of data in their Redux state and/or share pieces of that state among multiple components
+- Test Redux logic (actions, selectors, and/or reducers) in isolation from React components
+
+## How Is `mock-redux` Different Than Other Redux Test Libraries?
+
+Most Redux-focused testing libraries aim to set up Redux logic in unit tests for your React components to use.
+[`redux-mock-store`](https://github.com/reduxjs/redux-mock-store), for example, has useful utilities around setting up a mocked version of your Redux store for unit tests.
+
+In a sense, other libraries tend to augment or swap out _Redux_:
+
+```
+react <-----> react-redux <-----> redux
+                                  |___|
+                                    ^
+                                    |
+                              redux-mock-store
+```
+
+`mock-redux` completely swaps out the _`react-redux`_ library from your code, leaving your unit tests just testing the logic in your React components.
+
+```
+react <-----> react-redux ...
+              |_________|
+                   ^
+                   |
+              mock-redux
+```
+
+## How Does `mock-redux` Work?
+
+[Jest module mocks](https://jestjs.io/docs/en/mock-functions#mocking-modules).
+The entire `react-redux` module is replaced with `mock-redux` logic, so your React components only ever interact with stubbed versions of `connect`, `useSelector`, and `useDispatch`.
+
+- `useSelector` is replaced by a function that:
+  - Calls a predefined mock if you've defined a return value with `.give` or mock with `.giveMock` for that selector
+  - Otherwise passes the state you defined for the test to that selector
+- `useDispatch` returns the same mock created by a `jest.fn()` and returned as a member of `fetchMock()`
+- `connect` mimicks `react-redux` but using the above mock logic
+
+## Should I Mock State or Mock Selectors?
+
+That's up to you.
+
+If your application already tests its Redux state separately, or you otherwise don't want to mix your Redux logic in your React views, `.give` is a great way to separate the two.
+Its only caveat is that it doesn't allow inline ("curried") selectors like `useSelector(state => selectSomeState(state, true))`.
+
+Otherwise, if you either prefer including the shape of your Redux state in your React tests or generally cannot use `.give`, use `.state` to set up mock states per test.
+
+## Help! My `.give` Selectors Aren't Getting Mocked!?
+
+`mock-redux` can only mock out selectors that are _directly_ passed to `useSelector`:
+
+```tsx
+useSelector(selectValue);
+```
+
+If you pass anything else, such as a function wrapping around a selector...
+
+```tsx
+useSelector((state) => selectValueByKey(state, "someKey"));
+```
+
+...then `mock-redux` won't be able to mock out the call to `selectValue`, and the original function will get used.
+
+You have few couple options for dealing with this situation:
+
+- Figure out a way to move whatever logic generated the selector into Redux, so you can directly pass a selector into it
+  - Example:
+  ```tsx
+  const someValue = useSelector(selectValueUnderSomeKey);
+  ```
+  - Protip: [`reselect`](https://github.com/reduxjs/reselect) can help you compose selectors
+- Figure out a way to move the extra logic in the component to outside the selector call, so you can pass the selector directly to `useSelector` and perform logic on it after
+  - Example:
+    ```tsx
+    const values = useSelector(selectValues);
+    const someValue = values.someKey;
+    ```
+- Use `mock-redux`'s `.state` API to pass a custom state to your selector

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -16,6 +16,10 @@ This approach is particularily effective in applications that do some or all of:
 
 See Mark Erikson's [Redux testing strategy blog post](https://blog.isquaredsoftware.com/2019/07/blogged-answers-thoughts-on-hooks/) for prior discussion and thoughts.
 
+> Is React your actual "app"?
+> Or is it "just" the UI layer, with the real app being the logic and data kept outside the component tree?
+> Both are very valid viewpoints, again with differing tradeoffs.
+
 ## How Is `mock-redux` Different Than Other Redux Test Libraries?
 
 Most Redux-focused testing libraries aim to set up Redux logic in unit tests for your React components to use.

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -22,8 +22,8 @@ See Mark Erikson's [Redux testing strategy blog post](https://blog.isquaredsoftw
 
 ## How Is `mock-redux` Different Than Other Redux Test Libraries?
 
-Most Redux-focused testing libraries aim to set up Redux logic in unit tests for your React components to use.
-[`redux-mock-store`](https://github.com/reduxjs/redux-mock-store), for example, has useful utilities around setting up a mocked version of your Redux store for unit tests.
+Most Redux-focused testing libraries aim to set up Redux logic in tests for your React components to use.
+[`redux-mock-store`](https://github.com/reduxjs/redux-mock-store), for example, has useful utilities around setting up a mocked version of your Redux store for tests.
 
 In a sense, other libraries tend to augment or swap out _Redux_:
 
@@ -35,7 +35,7 @@ react <-----> react-redux <-----> redux
                               redux-mock-store
 ```
 
-`mock-redux` completely swaps out the _`react-redux`_ library from your code, leaving your unit tests just testing the logic in your React components.
+`mock-redux` completely swaps out the _`react-redux`_ library from your code, leaving your tests just testing the logic in your React components.
 
 ```
 react <-----> react-redux ...

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -114,7 +114,7 @@ mockRedux().giveMock(
 
 See [Jest's mock functions](https://jestjs.io/docs/en/mock-functions.html) for full documentation.
 
-> See [FAQs](./FAQ) for help choosing between these strategies and pracices for mocking selectors.
+> See [FAQs](./FAQs.md) for help choosing between these strategies and pracices for mocking selectors.
 
 ## Examples
 

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -50,12 +50,12 @@ It can be useful to separate view and state logic in tests: especially when stat
 Instead, `mock-redux` can _simplify_ or even _replace_ any Redux interactions.
 You have two options:
 
-- Providing a mocked Redux state for your unit test
+- Providing a mocked Redux state for your test
 - Directly using predefined return values or mock functions for individual selectors
 
 ## Mocking State
 
-You can set mock Redux state for the duration of a unit test.
+You can set mock Redux state for the duration of a test.
 That state will be provided to selectors called by `useSelector`.
 
 ```tsx
@@ -67,9 +67,9 @@ mockRedux().state({
 <Heading />;
 ```
 
-`.state` takes in a single parameter and can only be called once per unit test:
+`.state` takes in a single parameter and can only be called once per test:
 
-- `state`: A value to use as the root Redux state for the duration of the unit test
+- `state`: A value to use as the root Redux state for the duration of the test
 
 ## Mocking Selectors
 

--- a/docs/Selectors.md
+++ b/docs/Selectors.md
@@ -114,14 +114,7 @@ mockRedux().giveMock(
 
 See [Jest's mock functions](https://jestjs.io/docs/en/mock-functions.html) for full documentation.
 
-### Which Should I Use?
-
-That's up to you.
-
-If your application already tests its Redux state separately, or you otherwise don't want to mix your Redux logic in your React views, `.give` is a great way to separate the two.
-Its only caveat is that it doesn't allow inline ("curried") selectors like `useSelector(state => selectSomeState(state, true))`.
-
-Otherwise, if you either prefer including the shape of your Redux state in your React tests or generally cannot use `.give`, use `.state` to set up mock states per test.
+> See [FAQs](./FAQ) for help choosing between these strategies and pracices for mocking selectors.
 
 ## Examples
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+This folder contains a few test files showcasing basic usage of `mock-redux` with `@testing-library/react`.
+
+| Example                        | Selectors | Dispatches |
+| ------------------------------ | --------- | ---------- |
+| [Clicker](./docs/Clicker.md)   | ✅        |            |
+| [Heading](./docs/Heading.md)   |           | ✅         |
+| [Tracking](./docs/Tracking.md) | ✅        | ✅         |

--- a/docs/examples/types.d.ts
+++ b/docs/examples/types.d.ts
@@ -1,3 +1,7 @@
+// This types.d.ts file allows the tests in this ./docs/examples/ folder to not fail TypeScript compilation.
+// These documentation test examples are actually run as part of this repository's `yarn test` command.
+// Kind of cool, right? 🤗
+
 declare module "mock-redux" {
   const _: typeof import("../../src/index");
   export = _;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Codecademy",
-  "description": "Mocks out Redux actions and selectors for clean React unit tests in Jest.",
+  "description": "Mocks out Redux actions and selectors for clean React Jest tests.",
   "devDependencies": {
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",


### PR DESCRIPTION
Fixes #5. I figured a traditional FAQs page is probably more relevant at this early point than a high-level philosophy page. 

Also stops referring to _unit_ (tests) anywhere in the repository. I personally think of this as a unit testing library but there are projects out there with testing methodologies other than _unit_ testing (e.g. integration testing).